### PR TITLE
fix: web scrape timeout

### DIFF
--- a/prediction_prophet/functions/web_scrape.py
+++ b/prediction_prophet/functions/web_scrape.py
@@ -17,7 +17,7 @@ def fetch_html(url: str, timeout: int) -> Response:
     return response
 
 
-def web_scrape(url: str, timeout: int = 10000) -> str:
+def web_scrape(url: str, timeout: int = 10) -> str:
     try:
         response = fetch_html(url=url, timeout=timeout)
 


### PR DESCRIPTION
timeout in [requests is expected to be set as seconds](https://requests.readthedocs.io/en/stable/user/advanced/#timeouts) instead of ms - now we wait 10 seconds if a scrape doesn't goes through